### PR TITLE
Strict syntax

### DIFF
--- a/can-dom-events.js
+++ b/can-dom-events.js
@@ -20,48 +20,33 @@ var domEvents = {
         return this._eventRegistry.add(event, eventType);
     },
 
-	addEventListener: function() {
-        var args = util.addDomContext(this, arguments);
-        var eventType = args[1];
+	addEventListener: function(target, eventType) {
         var hasCustomEvent = domEvents._eventRegistry.has(eventType);
         if (hasCustomEvent) {
-            var eventDefinition = domEvents._eventRegistry.get(eventType);
-            return eventDefinition.addEventListener.apply(domEvents, args);
+            var event = domEvents._eventRegistry.get(eventType);
+            return event.addEventListener.apply(domEvents, arguments);
         }
 
-        var target = args[0];
-		var eventArgs = Array.prototype.slice.call(args, 1);
+		var eventArgs = Array.prototype.slice.call(arguments, 1);
         return target.addEventListener.apply(target, eventArgs);
 	},
     
-	removeEventListener: function() {
-        var args = util.addDomContext(this, arguments);
-        var eventType = args[1];
+	removeEventListener: function(target, eventType) {
         var hasCustomEvent = domEvents._eventRegistry.has(eventType);
         if (hasCustomEvent) {
-            var eventDefinition = domEvents._eventRegistry.get(eventType);
-            return eventDefinition.removeEventListener.apply(domEvents, args);
+            var event = domEvents._eventRegistry.get(eventType);
+            return event.removeEventListener.apply(domEvents, arguments);
         }
 
-		var target = args[0];
-		var eventArgs = Array.prototype.slice.call(args, 1);
+		var eventArgs = Array.prototype.slice.call(arguments, 1);
         return target.removeEventListener.apply(target, eventArgs);
 	},
 
-	canAddEventListener: function() {
-        var target = util.addDomContext(this, arguments)[0];
-		return util.isDomEventTarget(target);
-	},
+	canAddEventListener: util.isDomEventTarget,
 
-	dispatch: function() {
-        var args = util.addDomContext(this, arguments);
-        var target = args[0];
-        var eventData = args[1];
-        var eventArgs = args[2];
-        var bubbles = args[3];
+	dispatch: function(target, eventData, eventArgs, bubbles) {
         var cancelable = false;
-
-		var event = util.createEvent(this, eventData, eventArgs, bubbles, cancelable);
+		var event = util.createEvent(target, eventData, eventArgs, bubbles, cancelable);
 		var enableForDispatch = util.forceEnabledForDispatch(target, event);
 		if(enableForDispatch) {
 			target.disabled = false;

--- a/helpers/add-event-compat.js
+++ b/helpers/add-event-compat.js
@@ -1,3 +1,4 @@
+'use strict';
 /*
 	This module conforms to the can-util 3.x custom event
 	overriding behavior. This module is a compatibility

--- a/helpers/add-event-jquery.js
+++ b/helpers/add-event-jquery.js
@@ -19,9 +19,7 @@ module.exports = function addEventJQuery (jQuery, customEvent, customEventType) 
         removeEventListener (target, eventType, handler) {
             $(target).off(eventType, handler);
         },
-        canAddEventListener (target) {
-            return util.isDomEventTarget(target);
-        },
+        canAddEventListener: util.isDomEventTarget,
         dispatch (target) {
             var event = util.createEvent.apply(null, arguments);
             $(target).trigger(event);

--- a/helpers/add-event-jquery.js
+++ b/helpers/add-event-jquery.js
@@ -1,3 +1,4 @@
+'use strict';
 /*
     This module makes can-dom-event custom events
     work with jQuery instead of can-dom-events.


### PR DESCRIPTION
Instead of supporting both `domEvents.addEventListener(target, ...)` and `domEvents.addEventListener.call(target, ...)` we should only use the newer `domEvents.addEventListener(target, ...)` and let the compat layer deal with the inconsistencies of working with the older `can-util/dom/events` style.