### PR TITLE
Landscaper: Remove deprecated can-util methods and replace with can-globals

### DIFF
--- a/helpers/util.js
+++ b/helpers/util.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var getCurrentDocument = require("can-util/dom/document/document");
+var getCurrentDocument = require("can-globals/document/document");
 var isBrowserWindow = require("can-util/js/is-browser-window/is-browser-window");
 
 function getTargetDocument (target) {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
   },
   "dependencies": {
     "can-namespace": "^1.0.0",
-    "can-util": "^3.8.4"
+    "can-util": "^3.8.4",
+    "can-globals": "^0.1.0"
   },
   "devDependencies": {
     "fixpack": "^2.3.1",


### PR DESCRIPTION
This pull request was created with [Landscaper](https://github.com/bitovi/landscaper).
The following code mods were used to create this PR:

1. **https://gist.github.com/imaustink/d1faff15b89df8fb7964c5d5c3945e72**

Please review this PR carefully as Landscaper does not guarantee any code mod's quality.