### PR TITLE
Remove can-util as dependency

### DIFF
--- a/helpers/util.js
+++ b/helpers/util.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var getCurrentDocument = require("can-globals/document/document");
-var isBrowserWindow = require("can-util/js/is-browser-window/is-browser-window");
+var isBrowserWindow = require("can-globals/is-browser-window/is-browser-window");
 
 function getTargetDocument (target) {
 	return target.ownerDocument || getCurrentDocument();

--- a/package.json
+++ b/package.json
@@ -11,9 +11,8 @@
     "url": "https://github.com/canjs/can-dom-events/issues"
   },
   "dependencies": {
-    "can-namespace": "^1.0.0",
-    "can-util": "^3.8.4",
-    "can-globals": "^0.1.0"
+    "can-globals": "^0.2.2",
+    "can-namespace": "^1.0.0"
   },
   "devDependencies": {
     "fixpack": "^2.3.1",


### PR DESCRIPTION
Also, use `can-dom-data-state` and `globals/browser-window`