### PR TITLE
Support Edge 14

### DIFF
--- a/helpers/-make-delegate-event-tree.js
+++ b/helpers/-make-delegate-event-tree.js
@@ -23,7 +23,9 @@ function makeDelegator (domEvents) {
 					do {
 						// document does not implement `.matches` but documentElement does
 						var el = cur === document ? document.documentElement : cur;
-						if (el.matches(selector)) {
+						var matches = el.matches || el.msMatchesSelector;
+
+						if (matches.call(el, selector)) {
 							handlers.forEach(function(handler){
 								handler.call(el, ev);
 							});


### PR DESCRIPTION
Closes #44

```
However, given the practicality of supporting older browsers,
the following should suffice for most (if not all) practical cases (i.e. IE9+ support).

if (!Element.prototype.matches) {
    Element.prototype.matches = Element.prototype.msMatchesSelector;
}
```

![screen shot 2018-03-02 at 4 22 12 pm](https://user-images.githubusercontent.com/724877/36926635-1412d656-1e36-11e8-9000-16226a2dcd4b.png)
