### PR TITLE
Exclude nodes without 'matches' (e.g. comment and text) from delegation tests

### DIFF
--- a/helpers/-make-delegate-event-tree.js
+++ b/helpers/-make-delegate-event-tree.js
@@ -26,7 +26,9 @@ function makeDelegator (domEvents) {
 						var el = cur === document ? document.documentElement : cur;
 						var matches = el.matches || el.msMatchesSelector;
 
-						if (matches.call(el, selector)) {
+						// Text and comment nodes may be included in mutation event targets
+						//  but will never match selectors (and do not implement matches)
+						if (matches && matches.call(el, selector)) {
 							handlers.forEach(function(handler){
 								handler.call(el, ev);
 							});


### PR DESCRIPTION
This mostly applies to mutation events, which seem to fire on non-element nodes as well.  Expecting HTMLElement.prototype.matches to exist on those nodes will fail when checking whether they're delegation targets.  This is a quick fix to guard against that error.