### PR TITLE
Warning thrown when adding duplicate event to registry

### DIFF
--- a/helpers/make-event-registry-test.js
+++ b/helpers/make-event-registry-test.js
@@ -66,3 +66,21 @@ unit.test('get should return the register event', function (assert) {
 	remove();
 	assert.equal(registry.get(eventType), undefined, 'empty registry should not have the event');
 });
+
+unit.test('checks if custom event is already registered (#72)', function (assert) {
+	var eventType = 'boi';
+	var exampleEvent = {
+		defaultEventType: eventType,
+		addEventListener: function () {},
+		removeEventListener: function () {}
+	};
+
+	var registry = makeEventRegistry();
+	assert.equal(registry.has(eventType), false, 'initial registry should not have the event');
+
+	registry.add(exampleEvent, eventType);
+	assert.equal(registry.has(eventType), true, 'updated registry should have the event');
+
+	// In production, an Error is thrown
+	assert.equal(registry.add(exampleEvent, eventType), undefined, 'returns undefined if an event is already registered in development');
+});

--- a/helpers/make-event-registry.js
+++ b/helpers/make-event-registry.js
@@ -90,10 +90,8 @@ EventRegistry.prototype.add = function (event, eventType) {
 
 	if (this.has(eventType)) {
 		if (process.env.NODE_ENV !== 'production') {
-			if (this.has(eventType)) {
 				dev.warn('Event "' + eventType + '" is already registered');
 				return;
-			}
 		}
 
 		throw new Error('Event "' + eventType + '" is already registered');

--- a/helpers/make-event-registry.js
+++ b/helpers/make-event-registry.js
@@ -1,5 +1,7 @@
 'use strict';
 
+var dev = require('can-log/dev/dev');
+
 function EventRegistry () {
 	this._registry = {};
 }
@@ -87,6 +89,13 @@ EventRegistry.prototype.add = function (event, eventType) {
 	}
 
 	if (this.has(eventType)) {
+		if (process.env.NODE_ENV !== 'production') {
+			if (this.has(eventType)) {
+				dev.warn('Event "' + eventType + '" is already registered');
+				return;
+			}
+		}
+
 		throw new Error('Event "' + eventType + '" is already registered');
 	}
 

--- a/package.json
+++ b/package.json
@@ -13,11 +13,13 @@
   "dependencies": {
     "can-globals": "<2.0.0",
     "can-key-tree": "^1.0.0",
+    "can-log": "^1.0.2",
     "can-namespace": "^1.0.0",
     "can-reflect": "^1.11.1"
   },
   "devDependencies": {
     "detect-cyclic-packages": "^1.1.0",
+    "done-serve": "^2.3.0",
     "fixpack": "^2.3.1",
     "jquery": "^3.2.1",
     "jshint": "^2.9.1",
@@ -42,6 +44,7 @@
   },
   "scripts": {
     "build": "node build.js",
+    "develop": "done-serve --static --develop --port 8080",
     "detect-cycle": "detect-cyclic-packages --ignore done-serve",
     "jshint": "jshint ./*.js ./helpers/*.js --config",
     "lint": "fixpack && npm run jshint",


### PR DESCRIPTION
In development, if a custom event is added to the registry a second time, a warning will be given and return undefined.

In production, if a custom event is added to the registry a second time, an Error will be thrown.